### PR TITLE
feat: use git rerere to merge package.json then package-lock.json

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -59,6 +59,7 @@ if (fs.existsSync(attrFile)) {
 if (attrContents && !attrContents.match(/[\n\r]$/g)) {
   attrContents = '\n';
 }
+attrContents += 'package.json merge=npm-merge-driver-install\n';
 attrContents += 'npm-shrinkwrap.json merge=npm-merge-driver-install\n';
 attrContents += 'package-lock.json merge=npm-merge-driver-install\n';
 

--- a/src/merge.js
+++ b/src/merge.js
@@ -3,16 +3,29 @@ const spawnSync = require('child_process').spawnSync;
 const path = require('path');
 const fs = require('fs');
 const logger = require('./console');
-
 const currentVersion = process.argv[2];
 const ancestorVersion = process.argv[3];
 const otherVersion = process.argv[4];
 const file = process.argv[5];
+const rerere = spawnSync('git', ['config', '--get', 'rerere.enabled'])
+  .stdout
+  .toString()
+  .trim()
+  .toLowerCase() === 'true';
 
-logger.log(`attempting to merge ${file} via npm i --package-lock-only`);
+if (path.basename(file) === 'package.json') {
+  if (rerere) {
+    logger.log('using git rerere to try and merge package.json');
+    spawnSync('git', ['rerere'], {stdio: 'inherit'});
+    process.exit(0);
+  }
+}
+
 const ret = spawnSync('git', ['merge-file', '-p', currentVersion, ancestorVersion, otherVersion], {stdio: [0, 'pipe', 2]});
 
 fs.writeFileSync(file, ret.stdout);
+
+logger.log(`attempting to merge ${file} via npm i --package-lock-only`);
 const install = spawnSync(
   'npm',
   ['install', '--package-lock-only', '--prefer-offline', '--no-audit', '--progress=false'],


### PR DESCRIPTION
Should allow auto-merging of package.json when we have a previous resolution and `git rerere` is enabled. Might be too smart, I will play around with it locally for awhile.